### PR TITLE
Update heroku postgreSQL database connection string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const { Pool } = require('pg');
 const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
+  connectionString: process.env.DATABASE_URL || "postgres://daligvqcctaqsd:873faae85e7344cb904b3391f8572b4f740bf58ff535fc072b41112b88b73083@ec2-50-17-197-184.compute-1.amazonaws.com:5432/d7h6tjbgnjk8vl",
   ssl: {
     rejectUnauthorized: false
   }


### PR DESCRIPTION
When attempting to connect to the PostgreSQL database provisioned by Heroku, a string URL is required to connect. However, the URL is only available to be read by a variable when connected to the Heroku server itself (i.e. when the app is running on the live site) and it is not available when running locally on localhost, causing apps to crash. This replaces the variable with the direct URL as taken from Heroku directly, though according to the Heroku docs this URL does change from time to time and so it may be necessary to update it in the future or find a more programmatic way to fetch this URL.