### PR TITLE
Add check to see if the product is a custom product before attempting to access the FoodType input field

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -69,7 +69,10 @@ function editFridgeItem(event) {
   console.log(event.target.value)
   console.log(document.getElementById(event.target.value + "EditQuantity").value)
   console.log(document.getElementById(event.target.value + "EditExpiryDate").value)
-  console.log(document.getElementById(event.target.value + "FoodType").value)
+  var customProduct = document.getElementById(event.target.value + "FoodType") != null;
+  if (customProduct) {
+    console.log(document.getElementById(event.target.value + "FoodType").value)
+  }
 
   if (document.getElementById(event.target.value + "EditQuantity").value == "" &&
     document.getElementById(event.target.value + "EditExpiryDate").value == "" &&
@@ -85,7 +88,7 @@ function editFridgeItem(event) {
     };
     userRequest.open('post', '/editFridgeItem');
     userRequest.setRequestHeader("Content-Type", "application/json;charset=UTF-8")
-    userRequest.send(JSON.stringify({'product': event.target.value, 'quantity': document.getElementById(event.target.value + "EditQuantity").value, 'expirydate': document.getElementById(event.target.value + "EditExpiryDate").value, 'type': document.getElementById(event.target.value + "FoodType").value}));
+    userRequest.send(JSON.stringify({'product': event.target.value, 'quantity': document.getElementById(event.target.value + "EditQuantity").value, 'expirydate': document.getElementById(event.target.value + "EditExpiryDate").value, 'type': customProduct ? document.getElementById(event.target.value + "FoodType").value : null}));
   }
 }
 


### PR DESCRIPTION
A previous PR to add food type editing for custom products accidentally broke the edit function for non-custom products, as the edit function is trying to access the food type select input, which does not exist for non-custom products. This causes it to throw a null pointer exception error for non-custom products, crashing the function. This PR just adds a check to see if the product is in fact a custom product before attempting to access this food type input, so that it does not encounter this error.

To Test:
- Check out this branch in your editor and load up the site on localhost:5000
- Try editing a default, non-custom item (i.e. tomatoes) and see if you can successfully change the quantity and expiry date (you should be able to)