### PR TITLE
Edit Profile Unit Testing

### DIFF
--- a/index.js
+++ b/index.js
@@ -288,7 +288,21 @@ express()
       res.send(data.rows);
     });
   })
-  
+
+  .post('/getUserProfilesByName', jsonParser, async (req, res) => {
+    const client = await pool.connect();
+    await client.query(`SELECT * FROM users WHERE user_ID <> '1' and name = '${req.body.name}'` , function(err, data) {
+      res.send(data.rows);
+    });
+  })
+ 
+  .post('/getUserProfilesByEmail', jsonParser, async (req, res) => {
+    const client = await pool.connect();
+    await client.query(`SELECT * FROM users WHERE user_ID <> '1' and email = '${req.body.email}'` , function(err, data) {
+      res.send(data.rows);
+    });
+  })
+
   // login setup
 
   .use(passport.initialize())

--- a/index.js
+++ b/index.js
@@ -281,6 +281,13 @@ express()
       res.send(data.rows);
     });
   })
+
+  .post('/getUserProfile', jsonParser, async (req, res) => {
+    const client = await pool.connect();
+    await client.query(`SELECT * FROM users WHERE user_ID =' ${req.body.userID}'`, function(err, data) {
+      res.send(data.rows);
+    });
+  })
   
   // login setup
 

--- a/index.js
+++ b/index.js
@@ -284,7 +284,7 @@ express()
 
   .post('/getUserProfile', jsonParser, async (req, res) => {
     const client = await pool.connect();
-    await client.query(`SELECT * FROM users WHERE user_ID =' ${req.body.userID}'`, function(err, data) {
+    await client.query(`SELECT * FROM users WHERE user_ID ='${req.body.userID}'`, function(err, data) {
       res.send(data.rows);
     });
   })

--- a/test/test.js
+++ b/test/test.js
@@ -68,21 +68,19 @@ describe('Add and remove product functionality', function() {
   describe('Edit user profile functionality', function() {
     var userProfile;
     describe('When checking a user profile it', function() {
-        it('should return a result for that user before it edits the profile', async function(done) {
-            userProfile = await getUserProfile('1');
+        it('should return a result for that user before it edits the profile', async function() {
+            userProfile = await getUserProfile(1);
             expect(userProfile).to.be.not.empty;
-            done();
         });
-        it('should return a result for that user after it edits the profile', async function(done) {
+        it('should return a result for that user after it edits the profile', async function() {
             await axios.post("http://localhost:5000/editProfile", { username: 'Test Name', email: 'tester@gmail.com', postal_code: 'B0B 0B0' })
             .then(async () => {
-                userProfile = await getUserProfile('1');
+                userProfile = await getUserProfile(1);
                 expect(userProfile).to.be.not.empty;
-                done();
             })
         });
         it('should correctly recognize the name that was edited', async function() {
-            expect(userProfile[0].username).to.equal('Test Name');
+            expect(userProfile[0].name).to.equal('Test Name');
         });
         it('should correctly recognize the email that was edited', async function() {
             expect(userProfile[0].email).to.equal('tester@gmail.com');
@@ -90,10 +88,9 @@ describe('Add and remove product functionality', function() {
         it('should correctly recognize the postal code that was edited', async function() {
             expect(userProfile[0].postal_code).to.equal('B0B 0B0');
         });
-        it('should not edit other users\' information', async function(done) {
-            fridgeProduct = await getUserProfile('2');
+        it('should not edit other users\' information', async function() {
+            fridgeProduct = await getUserProfile(2);
             expect(userProfile[0].email).to.not.equal('tester@gmail.com');
-            done();
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -68,29 +68,32 @@ describe('Add and remove product functionality', function() {
   describe('Edit user profile functionality', function() {
     var userProfile;
     describe('When checking a user profile it', function() {
-        it('should return a result for that user before it edits the profile', async function() {
+        it('should return a result for that user before it edits the profile', async function(done) {
             userProfile = await getUserProfile('1');
             expect(userProfile).to.be.not.empty;
+            done();
         });
-        it('should return a result for that user after it edits the profile', async function() {
+        it('should return a result for that user after it edits the profile', async function(done) {
             await axios.post("http://localhost:5000/editProfile", { username: 'Test Name', email: 'tester@gmail.com', postal_code: 'B0B 0B0' })
             .then(async () => {
-                userProfile = await getUserProfile(1);
+                userProfile = await getUserProfile('1');
                 expect(userProfile).to.be.not.empty;
+                done();
             })
         });
         it('should correctly recognize the name that was edited', async function() {
-            expect(userProfile[0].name).to.equal('Test Name');
+            expect(userProfile[0].username).to.equal('Test Name');
         });
         it('should correctly recognize the email that was edited', async function() {
-            expect(userProfile[0].name).to.equal('tester@gmail.com');
+            expect(userProfile[0].email).to.equal('tester@gmail.com');
         });
         it('should correctly recognize the postal code that was edited', async function() {
             expect(userProfile[0].postal_code).to.equal('B0B 0B0');
         });
-        it('should not edit other users\' information', async function() {
-            fridgeProduct = await getUserProfile(2);
+        it('should not edit other users\' information', async function(done) {
+            fridgeProduct = await getUserProfile('2');
             expect(userProfile[0].email).to.not.equal('tester@gmail.com');
+            done();
         });
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,13 @@ function getFridgeProduct(product, userID) {
     })
 }
 
+function getUserProfile(userID) {
+    return new Promise(function(resolve, reject) {
+        axios.post("http://localhost:5000/getUserProfile", { userID: userID})
+        .then(res => resolve(res.data))
+    })
+}
+
 function getProduct(product, userID) {
     return new Promise(function(resolve, reject) {
         axios.post("http://localhost:5000/getProduct", { product: product, userID: userID })
@@ -57,6 +64,36 @@ describe('Add and remove product functionality', function() {
       });
     });
   });
+
+  describe('Edit user profile functionality', function() {
+    var userProfile;
+    describe('When checking a user profile it', function() {
+        it('should return a result for that user before it edits the profile', async function() {
+            userProfile = await getUserProfile('1');
+            expect(userProfile).to.be.not.empty;
+        });
+        it('should return a result for that user after it edits the profile', async function() {
+            await axios.post("http://localhost:5000/editProfile", { username: 'Test Name', email: 'tester@gmail.com', postal_code: 'B0B 0B0' })
+            .then(async () => {
+                userProfile = await getUserProfile(1);
+                expect(userProfile).to.be.not.empty;
+            })
+        });
+        it('should correctly recognize the name that was edited', async function() {
+            expect(userProfile[0].name).to.equal('Test Name');
+        });
+        it('should correctly recognize the email that was edited', async function() {
+            expect(userProfile[0].name).to.equal('tester@gmail.com');
+        });
+        it('should correctly recognize the postal code that was edited', async function() {
+            expect(userProfile[0].postal_code).to.equal('B0B 0B0');
+        });
+        it('should not edit other users\' information', async function() {
+            fridgeProduct = await getUserProfile(2);
+            expect(userProfile[0].email).to.not.equal('tester@gmail.com');
+        });
+    });
+});
 
 describe('Edit product functionality', function() {
     var fridgeProduct;

--- a/test/test.js
+++ b/test/test.js
@@ -89,7 +89,7 @@ describe('Add and remove product functionality', function() {
             expect(userProfile[0].postal_code).to.equal('B0B 0B0');
         });
         it('should not edit other users\' information', async function() {
-            fridgeProduct = await getUserProfile(2);
+            userProfile = await getUserProfile(2);
             expect(userProfile[0].email).to.not.equal('tester@gmail.com');
         });
     });

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,20 @@ function getUserProfile(userID) {
     })
 }
 
+function getUserProfilesByName(name) {
+    return new Promise(function(resolve, reject) {
+        axios.post("http://localhost:5000/getUserProfilesByName", { name: name})
+        .then(res => resolve(res.data))
+    })
+}
+
+function getUserProfilesByEmail(email) {
+    return new Promise(function(resolve, reject) {
+        axios.post("http://localhost:5000/getUserProfilesByEmail", { email: email})
+        .then(res => resolve(res.data))
+    })
+}
+
 function getProduct(product, userID) {
     return new Promise(function(resolve, reject) {
         axios.post("http://localhost:5000/getProduct", { product: product, userID: userID })
@@ -72,25 +86,45 @@ describe('Add and remove product functionality', function() {
             userProfile = await getUserProfile(1);
             expect(userProfile).to.be.not.empty;
         });
+        it('should have initial name', async function() {
+            expect(userProfile[0].name).to.equal('First Test');
+        });
+        it('should have initial email', async function() {
+            expect(userProfile[0].email).to.equal('test1@gmail.com');
+        });
+        it('should have initial postal code', async function() {
+            expect(userProfile[0].postal_code).to.equal('A1A 1A1');
+        });
         it('should return a result for that user after it edits the profile', async function() {
-            await axios.post("http://localhost:5000/editProfile", { username: 'Test Name', email: 'tester@gmail.com', postal_code: 'B0B 0B0' })
+            await axios.post("http://localhost:5000/editProfile", { username: 'Second Test', email: 'test2@gmail.com', postal_code: 'B0B 0B0' })
             .then(async () => {
                 userProfile = await getUserProfile(1);
                 expect(userProfile).to.be.not.empty;
             })
         });
         it('should correctly recognize the name that was edited', async function() {
-            expect(userProfile[0].name).to.equal('Test Name');
+            expect(userProfile[0].name).to.equal('Second Test');
         });
         it('should correctly recognize the email that was edited', async function() {
-            expect(userProfile[0].email).to.equal('tester@gmail.com');
+            expect(userProfile[0].email).to.equal('test2@gmail.com');
         });
         it('should correctly recognize the postal code that was edited', async function() {
             expect(userProfile[0].postal_code).to.equal('B0B 0B0');
         });
-        it('should not edit other users\' information', async function() {
-            userProfile = await getUserProfile(2);
-            expect(userProfile[0].email).to.not.equal('tester@gmail.com');
+        it('should not edit other users\' names', async function() {
+            userProfile = await getUserProfilesByName('Second Test');
+            expect(userProfile).to.be.empty;
+        });
+        it('should not edit other users\' email', async function() {
+            userProfile = await getUserProfilesByEmail('test2@gmail.com');
+            expect(userProfile).to.be.empty;
+        });
+        it('should reset profile to initial information', async function() {
+            await axios.post("http://localhost:5000/editProfile", { username: 'First Test', email: 'test1@gmail.com', postal_code: 'A1A 1A1' })
+            .then(async () => {
+                userProfile = await getUserProfile(1);
+                expect(userProfile).to.be.not.empty;
+            })
         });
     });
 });


### PR DESCRIPTION
This PR contains unit tests for the edit profile function using mocha + chai.  The code checks a user has the expected initial information on their profile, then sets their name, email and postal code to test values.  It then checks for these test values.  Next, it looks through all other users profiles to confirm only a single user's information was changed.  Finally, it resets the user's profile to the initial information.
Below is the output in the command line from running the tests:

Edit user profile functionality
    When checking a user profile it
      √ should return a result for that user before it edits the profile (545ms)
      √ should have initial name
      √ should have initial email
      √ should have initial postal code
      √ should return a result for that user after it edits the profile (745ms)
      √ should correctly recognize the name that was edited
      √ should correctly recognize the email that was edited
      √ should correctly recognize the postal code that was edited
      √ should not edit other users' names (556ms)
      √ should not edit other users' email (1044ms)
      √ should reset profile to initial information (778ms)